### PR TITLE
Update to gulp-sass v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-rev": "^5.1.0",
     "gulp-rev-replace": "^0.4.2",
-    "gulp-sass": "^2.0.3",
+    "gulp-sass": "^2.1.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.4.2",
     "gulp-util": "^3.0.6",


### PR DESCRIPTION
Foundation v6 is having a problem with a Sass related functionality.
